### PR TITLE
Allow countCorrectionBits to be tuned using the mod config

### DIFF
--- a/src/main/java/com/falsepattern/endlessids/IEConfig.java
+++ b/src/main/java/com/falsepattern/endlessids/IEConfig.java
@@ -8,6 +8,7 @@ public class IEConfig {
     public static boolean catchUnregisteredBlocks;
     public static boolean removeInvalidBlocks;
     public static boolean extendDataWatcher;
+    public static int countCorrectionBits;
     
     public static void init(final File file) {
         File newFile;
@@ -21,6 +22,7 @@ public class IEConfig {
         IEConfig.catchUnregisteredBlocks = IEConfig.config.getBoolean("CatchUnregisteredBlocks", Tags.MODNAME, false, "");
         IEConfig.removeInvalidBlocks = IEConfig.config.getBoolean("RemoveInvalidBlocks", Tags.MODNAME, false, "Remove invalid (corrupted) blocks from the game.");
         IEConfig.extendDataWatcher = IEConfig.config.getBoolean("ExtendDataWatcher", Tags.MODNAME, false, "Extend DataWatcher IDs. Vanilla limit is 31, new limit is 127.");
+        IEConfig.countCorrectionBits = IEConfig.config.getInt("UnusedIDBits", Tags.MODNAME, 0, 0, 12, "Setting this value greater than 0 will reduce RAM usage, at the cost of less available IDs.");
         IEConfig.config.save();
     }
     
@@ -28,5 +30,6 @@ public class IEConfig {
         IEConfig.catchUnregisteredBlocks = false;
         IEConfig.removeInvalidBlocks = false;
         IEConfig.extendDataWatcher = false;
+        IEConfig.countCorrectionBits = 0;
     }
 }

--- a/src/main/java/com/falsepattern/endlessids/constants/ExtendedConstants.java
+++ b/src/main/java/com/falsepattern/endlessids/constants/ExtendedConstants.java
@@ -1,10 +1,12 @@
 package com.falsepattern.endlessids.constants;
 
+import com.falsepattern.endlessids.IEConfig;
+
 public class ExtendedConstants {
     //Tunables
     public static final int bitsPerID = 24;
     public static final int bitsPerMetadata = 4;
-    public static final int countCorrectionBits = 0;
+    public static final int countCorrectionBits = IEConfig.countCorrectionBits;
 
     public static final int watchableBits = 7;
 


### PR DESCRIPTION
## Describe your changes

Currently the mod forcefully extends IDs to be up to 24 bits. However, a lot of arrays in 1.7.10 need to be allocated with a size equal to the ID count. This results in several hundred megabytes of RAM being wasted due to those ID slots never actually being used.

This PR solves the issue by allowing the modpack developer to adjust the number of bits used for IDs themselves. The default is still 24 but can be lowered down as far as the vanilla default of 12 to save memory.

## What kind of PR is this?

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have tested the code locally and it works
- [x] I followed the requirements set in the contribution document