### PR TITLE
Fix lotr make crash on starup

### DIFF
--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
@@ -123,7 +123,7 @@ public enum Mixin implements IMixin {
     LOTRBiomeVariantStorageMixin(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRBiomeVariantStorageMixin"),
     LOTRChunkProviderMixin(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRChunkProviderMixin"),
     LOTRChunkProviderUtumnoMixin(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRChunkProviderUtumnoMixin"),
-    LOTRPacketBiomeVariantsWatchHandlerMixin(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRPacketBiomeVariantsWatchHandlerMixin"),
+    LOTRPacketBiomeVariantsWatchHandler(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRPacketBiomeVariantsWatchHandler"),
     LOTRWorldChunkManagerMixin(Side.COMMON, condition(() -> GeneralConfig.extendBiome).and(require(TargetedMod.LOTR)), "biome.lotr.LOTRWorldChunkManagerMixin"),
     //endregion LOTR
     //region NaturesCompass


### PR DESCRIPTION
fix crash on starup , but lotr is again today incompatible with endlessids
```
[11:34:52] [main/FATAL]: Mixin prepare for mod endlessids failed preparing common.biome.lotr.LOTRPacketBiomeVariantsWatchHandlerMixin in mixins.endlessids.json: org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException The specified mixin 'com.falsepattern.endlessids.mixin.mixins.common.biome.lotr.LOTRPacketBiomeVariantsWatchHandlerMixin' was not found
org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException: The specified mixin 'com.falsepattern.endlessids.mixin.mixins.common.biome.lotr.LOTRPacketBiomeVariantsWatchHandlerMixin' was not found
	at org.spongepowered.asm.mixin.transformer.MixinInfo.<init>(MixinInfo.java:865) ~[+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinConfig.prepareMixins(MixinConfig.java:852) ~[+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinConfig.postInitialise(MixinConfig.java:797) ~[+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.prepareConfigs(MixinProcessor.java:568) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.select(MixinProcessor.java:462) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.checkSelect(MixinProcessor.java:438) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:290) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:234) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClassBytes(MixinTransformer.java:202) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.Proxy.transform(Proxy.java:72) [+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:279) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:176) [launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClassHelper(ClassLoader.java:957) [?:1.8.0_352]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:902) [?:1.8.0_352]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:885) [?:1.8.0_352]
	at java.lang.Class.forNameImpl(Native Method) [?:1.8.0_352]
	at java.lang.Class.forName(Class.java:424) [?:1.8.0_352]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:131) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
Caused by: java.lang.ClassNotFoundException: The specified mixin 'com.falsepattern.endlessids.mixin.mixins.common.biome.lotr.LOTRPacketBiomeVariantsWatchHandlerMixin' was not found
	at org.spongepowered.asm.mixin.transformer.MixinInfo.loadMixinClass(MixinInfo.java:1314) ~[+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinInfo.<init>(MixinInfo.java:858) ~[+unimixins-all-1.7.10-0.1.11.jar:0.12.2+mixin.0.8.5]
	... 18 more
[11:34:52] [main/ERROR]: Unable to launch
java.lang.ClassNotFoundException: net.minecraft.client.main.Main
	at java.lang.Class.forNameImpl(Native Method) ~[?:1.8.0_352]
	at java.lang.Class.forName(Class.java:424) ~[?:1.8.0_352]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:131) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]