### PR TITLE
Cubic Chunks Compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     // region Our deps
     implementationSplit("com.falsepattern:falsepatternlib-mc1.7.10:1.9.0")
     compileOnly("it.unimi.dsi:fastutil:8.5.16")
-    implementationSplit("com.falsepattern:chunkapi-mc1.7.10:0.6.4")
+    implementationSplit("com.falsepattern:chunkapi-mc1.7.10:0.8.0")
     // endregion
 
     // region maintained mods

--- a/src/main/java/com/falsepattern/endlessids/EndlessIDs.java
+++ b/src/main/java/com/falsepattern/endlessids/EndlessIDs.java
@@ -42,7 +42,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
      version = Tags.VERSION,
      name = Tags.MODNAME,
      acceptedMinecraftVersions = "[1.7.10]",
-     dependencies = "required-after:chunkapi@[0.6.4,);" +
+     dependencies = "required-after:chunkapi@[0.8.0,);" +
                     "required-after:falsepatternlib@[1.9.0,);" +
                     "after:antiidconflict")
 public class EndlessIDs {

--- a/src/main/java/com/falsepattern/endlessids/managers/BlockIDManager.java
+++ b/src/main/java/com/falsepattern/endlessids/managers/BlockIDManager.java
@@ -45,7 +45,7 @@ import static com.falsepattern.endlessids.constants.ExtendedConstants.blocksPerS
 import static com.falsepattern.endlessids.util.DataUtil.*;
 
 //NOTE: Also change the save logic in MapWriter mod if changing this
-public class BlockIDManager implements DataManager.PacketDataManager, DataManager.SubChunkDataManager, DataManager.BlockPacketDataManager {
+public class BlockIDManager implements DataManager.PacketDataManager, DataManager.CubicPacketDataManager, DataManager.SubChunkDataManager, DataManager.BlockPacketDataManager {
 
     @Override
     public String domain() {
@@ -258,5 +258,78 @@ public class BlockIDManager implements DataManager.PacketDataManager, DataManage
     @Override
     public void readBlockPacketFromBuffer(S23PacketBlockChange packet, PacketBuffer buffer) {
         packet.field_148883_d = Block.getBlockById(buffer.readInt());
+    }
+
+    @Override
+    public int maxPacketSizeCubic() {
+        return 3 * 16 * 16 * 16 + 4;
+    }
+
+    @Override
+    public void writeToBuffer(Chunk chunk, ExtendedBlockStorage extendedBlockStorage, ByteBuffer data) {
+        val subChunk = (SubChunkBlockHook) extendedBlockStorage;
+
+        data.put((byte) subChunk.eid$getBlockMask());
+
+        val b1 = subChunk.eid$getB1();
+        data.put(b1);
+
+        val b2Low = subChunk.eid$getB2Low();
+        if (b2Low == null) return;
+        data.put(b2Low.data);
+
+        val b2High = subChunk.eid$getB2High();
+        if (b2High == null) return;
+        data.put(b2High.data);
+
+        val b3 = subChunk.eid$getB3();
+        if (b3 != null) {
+            data.put(b3);
+        }
+    }
+
+    @Override
+    public void readFromBuffer(Chunk chunk, ExtendedBlockStorage extendedBlockStorage, ByteBuffer data) {
+        val subChunk = (SubChunkBlockHook) extendedBlockStorage;
+        val storageFlag = data.get();
+
+        val b1 = subChunk.eid$getB1();
+        data.get(b1);
+
+        if (storageFlag == 0b00) {
+            subChunk.eid$setB2Low(null);
+            subChunk.eid$setB2High(null);
+            subChunk.eid$setB3(null);
+            return;
+        }
+
+        var b2Low = subChunk.eid$getB2Low();
+        if (b2Low == null) {
+            b2Low = subChunk.eid$createB2Low();
+        }
+        data.get(b2Low.data);
+
+        if (storageFlag == 0b01) {
+            subChunk.eid$setB2High(null);
+            subChunk.eid$setB3(null);
+            return;
+        }
+
+        var b2High = subChunk.eid$getB2High();
+        if (b2High == null) {
+            b2High = subChunk.eid$createB2High();
+        }
+        data.get(b2High.data);
+
+        if (storageFlag == 0b10) {
+            subChunk.eid$setB3(null);
+            return;
+        }
+
+        var b3 = subChunk.eid$getB3();
+        if (b3 == null) {
+            b3 = subChunk.eid$createB3();
+        }
+        data.get(b3);
     }
 }

--- a/src/main/java/com/falsepattern/endlessids/managers/BlockMetaManager.java
+++ b/src/main/java/com/falsepattern/endlessids/managers/BlockMetaManager.java
@@ -44,7 +44,7 @@ import java.nio.ByteBuffer;
 import static com.falsepattern.endlessids.constants.ExtendedConstants.blocksPerSubChunk;
 
 //NOTE: Also change the save logic in MapWriter mod if changing this
-public class BlockMetaManager implements DataManager.PacketDataManager, DataManager.SubChunkDataManager, DataManager.BlockPacketDataManager {
+public class BlockMetaManager implements DataManager.PacketDataManager, DataManager.CubicPacketDataManager, DataManager.SubChunkDataManager, DataManager.BlockPacketDataManager {
 
     @Override
     public String domain() {
@@ -232,5 +232,61 @@ public class BlockMetaManager implements DataManager.PacketDataManager, DataMana
     @Override
     public void readBlockPacketFromBuffer(S23PacketBlockChange packet, PacketBuffer buffer) {
         packet.field_148884_e = buffer.readUnsignedShort();
+    }
+
+    @Override
+    public int maxPacketSizeCubic() {
+        return 2 * 16 * 16 * 16 + 4;
+    }
+
+    @Override
+    public void writeToBuffer(Chunk chunk, ExtendedBlockStorage extendedBlockStorage, ByteBuffer data) {
+        val subChunk = (SubChunkBlockHook) extendedBlockStorage;
+
+        data.put((byte) subChunk.eid$getMetadataMask());
+
+        val m1Low = subChunk.eid$getM1Low();
+        data.put(m1Low.data);
+
+        val m1High = subChunk.eid$getM1High();
+        if (m1High == null) return;
+        data.put(m1High.data);
+
+        val m2 = subChunk.eid$getM2();
+        if (m2 != null) {
+            data.put(m2);
+        }
+    }
+
+    @Override
+    public void readFromBuffer(Chunk chunk, ExtendedBlockStorage extendedBlockStorage, ByteBuffer data) {
+        val subChunk = (SubChunkBlockHook) extendedBlockStorage;
+        val storageFlag = data.get();
+
+        val m1Low = subChunk.eid$getM1Low();
+        data.get(m1Low.data);
+
+        if (storageFlag == 0b01) {
+            subChunk.eid$setM1High(null);
+            subChunk.eid$setM2(null);
+            return;
+        }
+
+        var m1High = subChunk.eid$getM1High();
+        if (m1High == null) {
+            m1High = subChunk.eid$createM1High();
+        }
+        data.get(m1High.data);
+
+        if (storageFlag == 0b10) {
+            subChunk.eid$setM2(null);
+            return;
+        }
+
+        var m2 = subChunk.eid$getM2();
+        if (m2 == null) {
+            m2 = subChunk.eid$createM2();
+        }
+        data.get(m2);
     }
 }


### PR DESCRIPTION
depends on: https://github.com/LegacyModdingMC/ChunkAPI/pull/18

This just implements `CubicPacketDataManager` on the block ID and meta `DataManager`s.

Chunk biomes aren't modified in CC, though there's a new 3d biome array for cubes so that I can add underground and sky biomes. It won't need any compatibility since I made sure it works with int biome IDs.