### PR TITLE
Add Compat to PersonalSpace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,7 +210,7 @@ dependencies {
     //Nostalgic World Generation 1.0.0
     compileOnly(deobfCurse("nostalgiagenerator-927053:4816167"))
 
-    //Factorization 0.8.109
+    //Personal Space 1.0.33
     compileOnly(deobfCurse("PersonalSpace-819596:6536785"))
 
     //RandomThings 2.2.4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,6 +210,9 @@ dependencies {
     //Nostalgic World Generation 1.0.0
     compileOnly(deobfCurse("nostalgiagenerator-927053:4816167"))
 
+    //Factorization 0.8.109
+    compileOnly(deobfCurse("PersonalSpace-819596:6536785"))
+
     //RandomThings 2.2.4
     compileOnly(deobfCurse("randomthings-59816:2225310"))
 

--- a/src/main/java/com/falsepattern/endlessids/mixin/mixins/common/biome/personalspace/PersonalChunkProviderMixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/mixins/common/biome/personalspace/PersonalChunkProviderMixin.java
@@ -1,0 +1,46 @@
+/*
+ * EndlessIDs
+ *
+ * Copyright (C) 2022-2025 FalsePattern, The MEGA Team
+ * All Rights Reserved
+ *
+ * The above copyright notice, this permission notice and the word "MEGA"
+ * shall be included in all copies or substantial portions of the Software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, only version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.falsepattern.endlessids.mixin.mixins.common.biome.personalspace;
+
+import com.falsepattern.endlessids.mixin.helpers.BiomePatchHelper;
+import me.eigenraven.personalspace.world.PersonalChunkProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.Chunk;
+
+@Mixin(PersonalChunkProvider.class)
+public class PersonalChunkProviderMixin {
+
+    @Shadow private int savedBiomeId = -1;
+
+    @Redirect(method = "provideChunk",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/world/chunk/Chunk;getBiomeArray()[B"),
+              require = 1)
+    private byte[] setBiomesTweaked(Chunk instance) {
+        return BiomePatchHelper.getBiomeArrayTweaked(instance, i -> BiomeGenBase.getBiome(savedBiomeId));
+    }
+}

--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
@@ -78,6 +78,7 @@ import static com.falsepattern.endlessids.mixin.plugin.TargetMod.Netherlicious;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.NomadicTents;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.NuclearTech;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.OldWorldGen;
+import static com.falsepattern.endlessids.mixin.plugin.TargetMod.PersonalSpace;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.RandomThings;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.RealisticTerrainGeneration;
 import static com.falsepattern.endlessids.mixin.plugin.TargetMod.RealisticWorldGen;
@@ -341,6 +342,11 @@ public enum Mixin implements IMixins {
                       Ext.Biome,
                       require(OldWorldGen),
                       common("biome.owg.ChunkGeneratorBetaMixin")),
+
+    Biome_PersonalSpace(Phase.LATE,
+                        Ext.Biome,
+                        require(PersonalSpace),
+                        common("biome.personalspace.PersonalChunkProviderMixin")),
 
     Biome_RandomThings(Phase.EARLY,
                        Ext.Biome,

--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/TargetMod.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/TargetMod.java
@@ -80,6 +80,7 @@ public enum TargetMod implements ITargetMod {
     NomadicTents("com.yurtmod.main.NomadicTents"),
     NuclearTech("com.hbm.main.MainRegistry"),
     OldWorldGen("owg.OWG"),
+    PersonalSpace("me.eigenraven.personalspace.PersonalSpaceMod"),
     Ruins("atomicstryker.ruins.common.RuinsMod"),
     RealisticTerrainGeneration("rtg.RTG"),
     RealisticWorldGen("rwg.RWG"),


### PR DESCRIPTION
closes: https://github.com/GTMEGA/EndlessIDs/issues/47
closes: https://github.com/GTNewHorizons/PersonalSpace/issues/33

PersonalSpace uses a vanilla chunk provider method getBiomeArray() in its generation code. this PR adds compat via mixin by changing it to the EID chunk array, populated by the biome id that is set in the PersonalSpace portal.